### PR TITLE
Add unary call to generation tests

### DIFF
--- a/protoc-gen-connect-kotlin/build.gradle.kts
+++ b/protoc-gen-connect-kotlin/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.assertj)
     testImplementation(libs.mockito)
+    testImplementation(libs.kotlin.coroutines.core)
 }

--- a/protoc-gen-connect-kotlin/build.gradle.kts
+++ b/protoc-gen-connect-kotlin/build.gradle.kts
@@ -28,4 +28,5 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.assertj)
+    testImplementation(libs.mockito)
 }

--- a/protoc-gen-connect-kotlin/src/main/kotlin/build/buf/protocgen/connect/Generator.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/build/buf/protocgen/connect/Generator.kt
@@ -23,10 +23,7 @@ import build.buf.connect.ServerOnlyStreamInterface
 import build.buf.protocgen.connect.internal.CodeGenerator
 import build.buf.protocgen.connect.internal.Plugin
 import build.buf.protocgen.connect.internal.getClassName
-import build.buf.protocgen.connect.internal.getClassNameForFile
-import build.buf.protocgen.connect.internal.getFileClassName
 import build.buf.protocgen.connect.internal.getFileJavaPackage
-import build.buf.protocgen.connect.internal.getJavaFileName
 import com.google.protobuf.Descriptors
 import com.google.protobuf.compiler.PluginProtos
 import com.squareup.kotlinpoet.ClassName

--- a/protoc-gen-connect-kotlin/src/main/kotlin/build/buf/protocgen/connect/Generator.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/build/buf/protocgen/connect/Generator.kt
@@ -23,7 +23,10 @@ import build.buf.connect.ServerOnlyStreamInterface
 import build.buf.protocgen.connect.internal.CodeGenerator
 import build.buf.protocgen.connect.internal.Plugin
 import build.buf.protocgen.connect.internal.getClassName
+import build.buf.protocgen.connect.internal.getClassNameForFile
+import build.buf.protocgen.connect.internal.getFileClassName
 import build.buf.protocgen.connect.internal.getFileJavaPackage
+import build.buf.protocgen.connect.internal.getJavaFileName
 import com.google.protobuf.Descriptors
 import com.google.protobuf.compiler.PluginProtos
 import com.squareup.kotlinpoet.ClassName
@@ -307,12 +310,12 @@ class Generator : CodeGenerator {
 
     private fun classNameFromType(descriptor: Descriptors.Descriptor): ClassName {
         // Get the package of the descriptor's file.
-        // e.g. "build.buf.connect"
+        // e.g. "build.buf.connect".
         val packageName = getFileJavaPackage(descriptor.file)
         // Get the fully qualified class name of the descriptor
         // and subtract the file's package.
         // e.g. "build.buf.connect.EmptyMessage.InnerMessage"
-        // becomes ["EmptyMessage", "InnerMessage"]
+        // becomes ["EmptyMessage", "InnerMessage"].
         val names = getClassName(descriptor)
             .removePrefix(packageName)
             .removePrefix(".")
@@ -320,7 +323,7 @@ class Generator : CodeGenerator {
         // Case when there is a nested entity.
         // e.g Nested message definitions and messages within "*OuterClass.java".
         if (names.size > 1) {
-            return ClassName(packageName, names.first(), *names.subList(1, names.size - 1).toTypedArray())
+            return ClassName(packageName, names.first(), *names.subList(1, names.size).toTypedArray())
         }
         return ClassName(packageName, names.first())
     }

--- a/protoc-gen-connect-kotlin/src/main/kotlin/build/buf/protocgen/connect/internal/ProtoHelpers.kt
+++ b/protoc-gen-connect-kotlin/src/main/kotlin/build/buf/protocgen/connect/internal/ProtoHelpers.kt
@@ -84,7 +84,7 @@ internal fun getProtocJavaFileName(descriptor: Descriptors.Descriptor): String {
         }
         fullName = getClassName(descriptor)
     } else {
-        fullName = getClassName(descriptor.file)
+        fullName = getClassNameForFile(descriptor.file)
     }
     return fullName.replace('.', '/') + ".java"
 }
@@ -102,7 +102,7 @@ internal fun getProtocJavaFileName(descriptor: Descriptors.EnumDescriptor): Stri
     val fullName: String = if (descriptor.file.options.javaMultipleFiles) {
         getClassName(descriptor)
     } else {
-        getClassName(descriptor.file)
+        getClassNameForFile(descriptor.file)
     }
     return fullName.replace('.', '/') + ".java"
 }
@@ -117,7 +117,7 @@ internal fun getProtocJavaFileName(descriptor: Descriptors.ServiceDescriptor): S
     val fullName: String = if (descriptor.file.options.javaMultipleFiles) {
         getClassName(descriptor)
     } else {
-        getClassName(descriptor.file)
+        getClassNameForFile(descriptor.file)
     }
     return fullName.replace('.', '/') + ".java"
 }
@@ -222,7 +222,7 @@ fun getJavaFileName(descriptor: Descriptors.Descriptor): String {
         }
         fullName = getClassName(descriptor)
     } else {
-        fullName = getClassName(descriptor.file)
+        fullName = getClassNameForFile(descriptor.file)
     }
     return fullName.replace('.', '/') + ".java"
 }
@@ -237,7 +237,7 @@ private fun toJavaName(fullName: String, file: FileDescriptor): String {
     if (file.options.javaMultipleFiles) {
         result.append(getFileJavaPackage(file))
     } else {
-        result.append(getClassName(file))
+        result.append(getClassNameForFile(file))
     }
     if (result.isNotEmpty()) {
         result.append('.')
@@ -280,7 +280,7 @@ internal fun getClassName(descriptor: Descriptors.ServiceDescriptor): String {
  * Returns the fully-qualified class name corresponding to the given
  * file descriptor.
  */
-internal fun getClassName(descriptor: FileDescriptor): String {
+internal fun getClassNameForFile(descriptor: FileDescriptor): String {
     val result = StringBuilder(getFileJavaPackage(descriptor))
     if (result.isNotEmpty()) {
         result.append('.')

--- a/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
+++ b/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
@@ -23,6 +23,7 @@ import buf.javamultiplefiles.unspecified.v1.UnspecifiedInnerMessageServiceClient
 import buf.javamultiplefiles.unspecified.v1.UnspecifiedServiceClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 class PluginGenerationTest {
 
@@ -31,6 +32,15 @@ class PluginGenerationTest {
         val request = NoPackage.SayRequest.newBuilder().setSentence("hello").build()
         assertThat(request.sentence).isEqualTo("hello")
     }
+
+    @Test
+    fun emptyPackageServiceRequest() {
+        val client = ElizaServiceClient(mock {  })
+        val request = NoPackage.SayRequest.newBuilder().setSentence("hello").build()
+        client.say(request, emptyMap())
+        assertThat(request.sentence).isEqualTo("hello")
+    }
+
 
     @Test
     fun multiFileEnabled() {

--- a/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
+++ b/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
@@ -12,15 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import buf.javamultiplefiles.disabled.v1.DisabledEmptyOuterClass
 import buf.javamultiplefiles.disabled.v1.DisabledEmptyServiceClient
 import buf.javamultiplefiles.disabled.v1.DisabledInnerMessageServiceClient
 import buf.javamultiplefiles.disabled.v1.DisabledServiceClient
+import buf.javamultiplefiles.enabled.v1.EnabledEmptyRPCRequest
 import buf.javamultiplefiles.enabled.v1.EnabledEmptyServiceClient
 import buf.javamultiplefiles.enabled.v1.EnabledInnerMessageServiceClient
 import buf.javamultiplefiles.enabled.v1.EnabledServiceClient
+import buf.javamultiplefiles.unspecified.v1.UnspecifiedEmptyOuterClass
 import buf.javamultiplefiles.unspecified.v1.UnspecifiedEmptyServiceClient
 import buf.javamultiplefiles.unspecified.v1.UnspecifiedInnerMessageServiceClient
 import buf.javamultiplefiles.unspecified.v1.UnspecifiedServiceClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -37,13 +43,19 @@ class PluginGenerationTest {
     fun emptyPackageServiceRequest() {
         val client = ElizaServiceClient(mock {  })
         val request = NoPackage.SayRequest.newBuilder().setSentence("hello").build()
-        client.say(request, emptyMap())
+        CoroutineScope(Dispatchers.IO).launch {
+            client.say(request, emptyMap())
+        }
         assertThat(request.sentence).isEqualTo("hello")
     }
 
 
     @Test
     fun multiFileEnabled() {
+        val client = EnabledEmptyServiceClient(mock { })
+        CoroutineScope(Dispatchers.IO).launch {
+            client.enabledEmptyRPC(EnabledEmptyRPCRequest.getDefaultInstance())
+        }
         assertThat(EnabledEmptyServiceClient::class.java).isNotNull
         assertThat(EnabledServiceClient::class.java).isNotNull
         assertThat(EnabledInnerMessageServiceClient::class.java).isNotNull
@@ -51,6 +63,10 @@ class PluginGenerationTest {
 
     @Test
     fun multiFileDisabled() {
+        val client = DisabledEmptyServiceClient(mock { })
+        CoroutineScope(Dispatchers.IO).launch {
+            client.disabledEmptyRPC(DisabledEmptyOuterClass.DisabledEmptyRPCRequest.getDefaultInstance())
+        }
         assertThat(DisabledEmptyServiceClient::class.java).isNotNull
         assertThat(DisabledServiceClient::class.java).isNotNull
         assertThat(DisabledInnerMessageServiceClient::class.java).isNotNull
@@ -58,6 +74,10 @@ class PluginGenerationTest {
 
     @Test
     fun multiFileUnspecified() {
+        val client = UnspecifiedEmptyServiceClient(mock { })
+        CoroutineScope(Dispatchers.IO).launch {
+            client.unspecifiedEmptyRPC(UnspecifiedEmptyOuterClass.UnspecifiedEmptyRPCRequest.getDefaultInstance())
+        }
         assertThat(UnspecifiedEmptyServiceClient::class.java).isNotNull
         assertThat(UnspecifiedServiceClient::class.java).isNotNull
         assertThat(UnspecifiedInnerMessageServiceClient::class.java).isNotNull

--- a/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
+++ b/protoc-gen-connect-kotlin/src/test/kotlin/PluginGenerationTest.kt
@@ -41,14 +41,13 @@ class PluginGenerationTest {
 
     @Test
     fun emptyPackageServiceRequest() {
-        val client = ElizaServiceClient(mock {  })
+        val client = ElizaServiceClient(mock { })
         val request = NoPackage.SayRequest.newBuilder().setSentence("hello").build()
         CoroutineScope(Dispatchers.IO).launch {
             client.say(request, emptyMap())
         }
         assertThat(request.sentence).isEqualTo("hello")
     }
-
 
     @Test
     fun multiFileEnabled() {


### PR DESCRIPTION
Noticed that this behavior hasn't been working exactly as expected for certain edge cases due to the exclusion from the `subList()` call