### PR TITLE
Ensure URL resiliency

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockito)
 
-    implementation(libs.okhttp.core)
     implementation(libs.moshiKotlin)
     implementation(libs.kotlin.coroutines.core)
 }

--- a/library/src/main/kotlin/build/buf/connect/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/build/buf/connect/ProtocolClientConfig.kt
@@ -21,6 +21,7 @@ import build.buf.connect.protocols.ConnectInterceptor
 import build.buf.connect.protocols.GRPCInterceptor
 import build.buf.connect.protocols.GRPCWebInterceptor
 import build.buf.connect.protocols.NetworkProtocol
+import java.net.URI
 
 /**
  *  Set of configuration used to set up clients.
@@ -44,6 +45,7 @@ class ProtocolClientConfig(
 ) {
     private val internalInterceptorFactoryList = mutableListOf<(ProtocolClientConfig) -> Interceptor>()
     private val compressionPools = mutableMapOf<String, CompressionPool>()
+    internal val baseUri: URI
 
     init {
         val protocolInterceptor: (ProtocolClientConfig) -> Interceptor = when (networkProtocol) {
@@ -66,6 +68,7 @@ class ProtocolClientConfig(
         for (compressionPool in compressionPools) {
             this.compressionPools.put(compressionPool.name(), compressionPool)
         }
+        baseUri = URI(host)
     }
 
     /**

--- a/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
@@ -30,7 +30,7 @@ import build.buf.connect.http.HTTPRequest
 import build.buf.connect.http.Stream
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.suspendCancellableCoroutine
-import okhttp3.HttpUrl.Companion.toHttpUrl
+import java.net.URI
 import java.net.URL
 import kotlin.coroutines.resume
 
@@ -53,9 +53,10 @@ class ProtocolClient(
         val serializationStrategy = config.serializationStrategy
         val requestCodec = serializationStrategy.codec(methodSpec.requestClass)
         try {
-            val httpURL = config.host.toHttpUrl().newBuilder().addPathSegment(methodSpec.path).build()
+            val host = URI(config.host)
+            val uri = URI(host.scheme, host.host, "/${methodSpec.path}", null)
             val unaryRequest = HTTPRequest(
-                url = httpURL.toUrl(),
+                url = uri.toURL(),
                 contentType = "application/${requestCodec.encodingName()}",
                 headers = headers,
                 message = requestCodec.serialize(request)

--- a/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
@@ -203,8 +203,7 @@ class ProtocolClient(
     }
 
     private fun <Input : Any, Output : Any> urlFromMethodSpec(methodSpec: MethodSpec<Input, Output>): URL {
-        val host = URI(config.host)
-        val uri = URI(host.scheme, host.host, "/${methodSpec.path}", null)
-        return uri.toURL()
+        val host = URI(config.host).resolve(methodSpec.path)
+        return host.toURL()
     }
 }

--- a/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
@@ -30,6 +30,7 @@ import build.buf.connect.http.HTTPRequest
 import build.buf.connect.http.Stream
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.net.URL
 import kotlin.coroutines.resume
 
@@ -52,8 +53,9 @@ class ProtocolClient(
         val serializationStrategy = config.serializationStrategy
         val requestCodec = serializationStrategy.codec(methodSpec.requestClass)
         try {
+            val httpURL = config.host.toHttpUrl().newBuilder().addPathSegment(methodSpec.path).build()
             val unaryRequest = HTTPRequest(
-                url = URL("${config.host}/${methodSpec.path}"),
+                url = httpURL.toUrl(),
                 contentType = "application/${requestCodec.encodingName()}",
                 headers = headers,
                 message = requestCodec.serialize(request)

--- a/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
@@ -53,10 +53,8 @@ class ProtocolClient(
         val serializationStrategy = config.serializationStrategy
         val requestCodec = serializationStrategy.codec(methodSpec.requestClass)
         try {
-            val host = URI(config.host)
-            val uri = URI(host.scheme, host.host, "/${methodSpec.path}", null)
             val unaryRequest = HTTPRequest(
-                url = uri.toURL(),
+                url = urlFromMethodSpec(methodSpec),
                 contentType = "application/${requestCodec.encodingName()}",
                 headers = headers,
                 message = requestCodec.serialize(request)
@@ -144,7 +142,7 @@ class ProtocolClient(
         val requestCodec = config.serializationStrategy.codec(methodSpec.requestClass)
         val responseCodec = config.serializationStrategy.codec(methodSpec.responseClass)
         val request = HTTPRequest(
-            url = URL("${config.host}/${methodSpec.path}"),
+            url = urlFromMethodSpec(methodSpec),
             contentType = "application/connect+${requestCodec.encodingName()}",
             headers = headers
         )
@@ -202,5 +200,11 @@ class ProtocolClient(
                 channel
             )
         )
+    }
+
+    private fun <Input : Any, Output : Any> urlFromMethodSpec(methodSpec: MethodSpec<Input, Output>): URL {
+        val host = URI(config.host)
+        val uri = URI(host.scheme, host.host, "/${methodSpec.path}", null)
+        return uri.toURL()
     }
 }

--- a/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
@@ -30,7 +30,6 @@ import build.buf.connect.http.HTTPRequest
 import build.buf.connect.http.Stream
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.suspendCancellableCoroutine
-import java.net.URI
 import java.net.URL
 import kotlin.coroutines.resume
 
@@ -203,7 +202,7 @@ class ProtocolClient(
     }
 
     private fun <Input : Any, Output : Any> urlFromMethodSpec(methodSpec: MethodSpec<Input, Output>): URL {
-        val host = URI(config.host).resolve(methodSpec.path)
+        val host = config.baseUri.resolve(methodSpec.path)
         return host.toURL()
     }
 }

--- a/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
@@ -1,0 +1,31 @@
+package build.buf.connect
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.net.MalformedURLException
+
+
+class ProtocolClientConfigTest {
+
+    @Test
+    fun hostUri() {
+        val config = ProtocolClientConfig(
+            host = "https://connect.build",
+            serializationStrategy = mock { }
+        )
+        assertThat(config.baseUri.host).isEqualTo("connect.build")
+        assertThat(config.baseUri.toURL()).isNotNull()
+    }
+
+    @Test(expected = MalformedURLException::class)
+    fun unsupportedSchemeErrorsWhenTranslatingtoURL() {
+        val config = ProtocolClientConfig(
+            host = "xhtp://connect.build",
+            serializationStrategy = mock { }
+        )
+        config.baseUri.toURL()
+        fail<Unit>("expecting URL construction to fail")
+    }
+}

--- a/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
@@ -1,3 +1,17 @@
+// Copyright 2022-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buf.connect
 
 import org.assertj.core.api.Assertions.assertThat

--- a/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
@@ -34,7 +34,7 @@ class ProtocolClientConfigTest {
     }
 
     @Test(expected = MalformedURLException::class)
-    fun unsupportedSchemeErrorsWhenTranslatingtoURL() {
+    fun unsupportedSchemeErrorsWhenTranslatingToURL() {
         val config = ProtocolClientConfig(
             host = "xhtp://connect.build",
             serializationStrategy = mock { }

--- a/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
@@ -1,0 +1,48 @@
+package build.buf.connect.impl
+
+import build.buf.connect.Codec
+import build.buf.connect.MethodSpec
+import build.buf.connect.ProtocolClientConfig
+import build.buf.connect.SerializationStrategy
+import okio.Buffer
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ProtocolClientTest {
+    private val serializationStrategy: SerializationStrategy = mock { }
+    private val codec: Codec<String> = mock { }
+
+    @Test
+    fun urlConfiguration() {
+        whenever(codec.encodingName()).thenReturn("testing")
+        whenever(codec.serialize(any())).thenReturn(Buffer())
+        whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
+
+        val client = ProtocolClient(
+            httpClient = mock { },
+            config = ProtocolClientConfig(
+                host = "https://buf.build/",
+                serializationStrategy = serializationStrategy,
+            )
+        )
+        client.unary("input", emptyMap(), MethodSpec(
+            path = "build.buf.connect.SomeService/Service",
+            String::class,
+            String::class
+        )) { _ -> }
+        val client2 = ProtocolClient(
+            httpClient = mock { },
+            config = ProtocolClientConfig(
+                host = "https://buf.build",
+                serializationStrategy = serializationStrategy,
+            )
+        )
+        client2.unary("input", emptyMap(), MethodSpec(
+            path = "build.buf.connect.SomeService/Service",
+            String::class,
+            String::class
+        )) { _ -> }
+    }
+}

--- a/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
@@ -29,7 +29,7 @@ class ProtocolClientTest {
     private val codec: Codec<String> = mock { }
 
     @Test
-    fun urlConfiguration() {
+    fun urlConfigurationHostWithTrailingSlash() {
         whenever(codec.encodingName()).thenReturn("testing")
         whenever(codec.serialize(any())).thenReturn(Buffer())
         whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
@@ -50,6 +50,10 @@ class ProtocolClientTest {
                 String::class
             )
         ) { _ -> }
+    }
+
+    @Test
+    fun urlConfigurationHostWithoutTrailingSlash() {
         val client2 = ProtocolClient(
             httpClient = mock { },
             config = ProtocolClientConfig(

--- a/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
@@ -18,6 +18,9 @@ import build.buf.connect.Codec
 import build.buf.connect.MethodSpec
 import build.buf.connect.ProtocolClientConfig
 import build.buf.connect.SerializationStrategy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import okio.Buffer
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -29,7 +32,7 @@ class ProtocolClientTest {
     private val codec: Codec<String> = mock { }
 
     @Test
-    fun urlConfigurationHostWithTrailingSlash() {
+    fun urlConfigurationHostWithTrailingSlashUnary() {
         whenever(codec.encodingName()).thenReturn("testing")
         whenever(codec.serialize(any())).thenReturn(Buffer())
         whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
@@ -53,15 +56,19 @@ class ProtocolClientTest {
     }
 
     @Test
-    fun urlConfigurationHostWithoutTrailingSlash() {
-        val client2 = ProtocolClient(
+    fun urlConfigurationHostWithoutTrailingSlashUnary() {
+        whenever(codec.encodingName()).thenReturn("testing")
+        whenever(codec.serialize(any())).thenReturn(Buffer())
+        whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
+
+        val client = ProtocolClient(
             httpClient = mock { },
             config = ProtocolClientConfig(
                 host = "https://buf.build",
                 serializationStrategy = serializationStrategy
             )
         )
-        client2.unary(
+        client.unary(
             "input",
             emptyMap(),
             MethodSpec(
@@ -70,5 +77,55 @@ class ProtocolClientTest {
                 String::class
             )
         ) { _ -> }
+    }
+
+    @Test
+    fun urlConfigurationHostWithTrailingSlashStreaming() {
+        whenever(codec.encodingName()).thenReturn("testing")
+        whenever(codec.serialize(any())).thenReturn(Buffer())
+        whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
+
+        val client = ProtocolClient(
+            httpClient = mock { },
+            config = ProtocolClientConfig(
+                host = "https://buf.build/",
+                serializationStrategy = serializationStrategy
+            )
+        )
+        CoroutineScope(Dispatchers.IO).launch {
+            client.stream(
+                emptyMap(),
+                MethodSpec(
+                    path = "build.buf.connect.SomeService/Service",
+                    String::class,
+                    String::class
+                )
+            )
+        }
+    }
+
+    @Test
+    fun urlConfigurationHostWithoutTrailingSlashStreaming() {
+        whenever(codec.encodingName()).thenReturn("testing")
+        whenever(codec.serialize(any())).thenReturn(Buffer())
+        whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
+
+        val client = ProtocolClient(
+            httpClient = mock { },
+            config = ProtocolClientConfig(
+                host = "https://buf.build",
+                serializationStrategy = serializationStrategy
+            )
+        )
+        CoroutineScope(Dispatchers.IO).launch {
+            client.stream(
+                emptyMap(),
+                MethodSpec(
+                    path = "build.buf.connect.SomeService/Service",
+                    String::class,
+                    String::class
+                )
+            )
+        }
     }
 }

--- a/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
@@ -1,3 +1,17 @@
+// Copyright 2022-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buf.connect.impl
 
 import build.buf.connect.Codec

--- a/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
@@ -24,25 +24,33 @@ class ProtocolClientTest {
             httpClient = mock { },
             config = ProtocolClientConfig(
                 host = "https://buf.build/",
-                serializationStrategy = serializationStrategy,
+                serializationStrategy = serializationStrategy
             )
         )
-        client.unary("input", emptyMap(), MethodSpec(
-            path = "build.buf.connect.SomeService/Service",
-            String::class,
-            String::class
-        )) { _ -> }
+        client.unary(
+            "input",
+            emptyMap(),
+            MethodSpec(
+                path = "build.buf.connect.SomeService/Service",
+                String::class,
+                String::class
+            )
+        ) { _ -> }
         val client2 = ProtocolClient(
             httpClient = mock { },
             config = ProtocolClientConfig(
                 host = "https://buf.build",
-                serializationStrategy = serializationStrategy,
+                serializationStrategy = serializationStrategy
             )
         )
-        client2.unary("input", emptyMap(), MethodSpec(
-            path = "build.buf.connect.SomeService/Service",
-            String::class,
-            String::class
-        )) { _ -> }
+        client2.unary(
+            "input",
+            emptyMap(),
+            MethodSpec(
+                path = "build.buf.connect.SomeService/Service",
+                String::class,
+                String::class
+            )
+        ) { _ -> }
     }
 }


### PR DESCRIPTION
Adding URI parsing resiliency by relying on `URI` to help parse the host and scheme. The previous implementation contained some brittleness when the user sets a host to be `https://example.com/` rather than `https://example.com`

Resolves https://github.com/bufbuild/connect-kotlin/issues/12