### PR TITLE
Expose okhttp dependency in the okhttp binary

### DIFF
--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.okhttp.core)
+    api(libs.okhttp.core)
     implementation(libs.kotlin.coroutines.core)
 
     api(project(":library"))


### PR DESCRIPTION
The current developer experience is that the user is required to include okhttp as a dependency when they depend on the okhttp flavor of connect-kotlin.

The change here is just to allow the user to not need to explicitly declare the okhttp dependency.