### PR TITLE
Add return result for stream send()

### DIFF
--- a/library/src/main/kotlin/build/buf/connect/BidirectionalStreamInterface.kt
+++ b/library/src/main/kotlin/build/buf/connect/BidirectionalStreamInterface.kt
@@ -15,6 +15,7 @@
 package build.buf.connect
 
 import kotlinx.coroutines.channels.ReceiveChannel
+import java.lang.Exception
 
 /**
  * Represents a bidirectional stream that can send request messages and initiate closes.
@@ -32,7 +33,7 @@ interface BidirectionalStreamInterface<Input, Output> {
      *
      * @param input The request message to send.
      */
-    suspend fun send(input: Input)
+    suspend fun send(input: Input): Result<Unit>
 
     /**
      * Close the stream. No calls to `send()` are valid after calling `close()`.

--- a/library/src/main/kotlin/build/buf/connect/BidirectionalStreamInterface.kt
+++ b/library/src/main/kotlin/build/buf/connect/BidirectionalStreamInterface.kt
@@ -31,11 +31,21 @@ interface BidirectionalStreamInterface<Input, Output> {
      * Send a request to the server over the stream.
      *
      * @param input The request message to send.
+     * @return [Result.success] on send success, [Result.failure] on
+     *         any sends which are not successful.
      */
     suspend fun send(input: Input): Result<Unit>
 
     /**
-     * Close the stream. No calls to `send()` are valid after calling `close()`.
+     * Close the stream. No calls to [send] are valid after calling [close].
      */
     fun close()
+
+    /**
+     * Determine if the underlying stream is closed.
+     *
+     * @return true if the underlying stream is closed. If the stream is still open,
+     *         this will return false.
+     */
+    fun isClosed(): Boolean
 }

--- a/library/src/main/kotlin/build/buf/connect/BidirectionalStreamInterface.kt
+++ b/library/src/main/kotlin/build/buf/connect/BidirectionalStreamInterface.kt
@@ -15,7 +15,6 @@
 package build.buf.connect
 
 import kotlinx.coroutines.channels.ReceiveChannel
-import java.lang.Exception
 
 /**
  * Represents a bidirectional stream that can send request messages and initiate closes.

--- a/library/src/main/kotlin/build/buf/connect/ClientOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/build/buf/connect/ClientOnlyStreamInterface.kt
@@ -27,7 +27,15 @@ interface ClientOnlyStreamInterface<Input, Output> {
     suspend fun send(input: Input): Result<Unit>
 
     /**
-     * Close the stream. No calls to `send()` are valid after calling `close()`.
+     * Close the stream. No calls to [send] are valid after calling [close].
      */
     fun close()
+
+    /**
+     * Determine if the underlying stream is closed.
+     *
+     * @return true if the underlying stream is closed. If the stream is still open,
+     *         this will return false.
+     */
+    fun isClosed(): Boolean
 }

--- a/library/src/main/kotlin/build/buf/connect/ClientOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/build/buf/connect/ClientOnlyStreamInterface.kt
@@ -24,7 +24,7 @@ interface ClientOnlyStreamInterface<Input, Output> {
      *
      * @param input The request message to send.
      */
-    suspend fun send(input: Input)
+    suspend fun send(input: Input): Result<Unit>
 
     /**
      * Close the stream. No calls to `send()` are valid after calling `close()`.

--- a/library/src/main/kotlin/build/buf/connect/ConnectError.kt
+++ b/library/src/main/kotlin/build/buf/connect/ConnectError.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
 
 /**
  * Typed error provided by Connect RPCs that may optionally wrap additional typed custom errors
- * using `details`.
+ * using [details].
  */
 data class ConnectError constructor(
     // The resulting status code.
@@ -35,7 +35,7 @@ data class ConnectError constructor(
 ) : Throwable(message, exception) {
 
     /**
-     * Unpacks values from `self.details` and returns the first matching error, if any.
+     * Unpacks values from [details] and returns the first matching error, if any.
      *
      * @return The unpacked typed error details, if available.
      */
@@ -51,7 +51,7 @@ data class ConnectError constructor(
     }
 
     /**
-     * Creates a new ConnectError with the specified CompletionParser.
+     * Creates a new [ConnectError] with the specified [ErrorDetailParser].
      */
     fun setErrorParser(errorParser: ErrorDetailParser): ConnectError {
         return ConnectError(

--- a/library/src/main/kotlin/build/buf/connect/SerializationStrategy.kt
+++ b/library/src/main/kotlin/build/buf/connect/SerializationStrategy.kt
@@ -19,7 +19,7 @@ import kotlin.reflect.KClass
 /**
  * The serialization strategy for completion events from gRPC or Connect.
  *
- * A base data type will need to implement a SerializationStrategy.
+ * A base data type will need to implement a [SerializationStrategy].
  */
 interface SerializationStrategy {
 

--- a/library/src/main/kotlin/build/buf/connect/ServerOnlyStreamInterface.kt
+++ b/library/src/main/kotlin/build/buf/connect/ServerOnlyStreamInterface.kt
@@ -33,11 +33,21 @@ interface ServerOnlyStreamInterface<Input, Output> {
      * Can only be called exactly one time when starting the stream.
      *
      * @param input The request message to send.
+     * @return [Result.success] on send success, [Result.failure] on
+     *         any sends which are not successful.
      */
-    suspend fun send(input: Input)
+    suspend fun send(input: Input): Result<Unit>
 
     /**
-     * Close the stream. No calls to `send()` are valid after calling `close()`.
+     * Close the stream. No calls to [send] are valid after calling [close].
      */
     fun close()
+
+    /**
+     * Determine if the underlying stream is closed.
+     *
+     * @return true if the underlying stream is closed. If the stream is still open,
+     *         this will return false.
+     */
+    fun isClosed(): Boolean
 }

--- a/library/src/main/kotlin/build/buf/connect/StreamResult.kt
+++ b/library/src/main/kotlin/build/buf/connect/StreamResult.kt
@@ -17,7 +17,7 @@ package build.buf.connect
 /**
  * Enumeration of result states that can be received over streams.
  *
- * A typical stream receives `Headers > Message > Message > Message ... > Complete`
+ * A typical stream receives [Headers] > [Message] > [Message] > [Message] ... > [Complete]
  */
 sealed class StreamResult<Output> constructor(
     val error: Throwable? = null
@@ -34,7 +34,7 @@ sealed class StreamResult<Output> constructor(
     /**
      * Get the ConnectError from the result.
      *
-     * @return The ConnectError if present, null otherwise.
+     * @return The [ConnectError] if present, null otherwise.
      */
     fun connectError(): ConnectError? {
         if (error is ConnectError) {

--- a/library/src/main/kotlin/build/buf/connect/compression/CompressionPool.kt
+++ b/library/src/main/kotlin/build/buf/connect/compression/CompressionPool.kt
@@ -20,11 +20,11 @@ import okio.Buffer
  * Conforming types provide the functionality to compress/decompress data using a specific
  * algorithm.
  *
- * `ProtocolClientInterface` implementations are expected to use the first compression pool with
- * a matching `name()` for decompressing inbound responses.
+ * [build.buf.connect.ProtocolClientInterface] implementations are expected to use the first compression pool with
+ * a matching [name] for decompressing inbound responses.
  *
  * Outbound request compression can be specified using additional options that specify a
- * `compressionName` that matches a compression pool's `name()`.
+ * `compressionName` that matches a compression pool's [name].
  */
 interface CompressionPool {
     /**

--- a/library/src/main/kotlin/build/buf/connect/http/TracingInfo.kt
+++ b/library/src/main/kotlin/build/buf/connect/http/TracingInfo.kt
@@ -15,7 +15,7 @@
 package build.buf.connect.http
 
 /**
- * Tracing metadata for HTTPClientInterface and Interceptors.
+ * Tracing metadata for [HTTPClientInterface] and [build.buf.connect.Interceptor].
  */
 data class TracingInfo(
     // The underlying http status code

--- a/library/src/main/kotlin/build/buf/connect/impl/BidirectionalStream.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/BidirectionalStream.kt
@@ -35,7 +35,7 @@ internal class BidirectionalStream<Input, Output>(
         val msg = try {
             requestCodec.serialize(input)
         } catch (e: Exception) {
-            return  Result.failure(e)
+            return Result.failure(e)
         }
         return stream.send(msg)
     }

--- a/library/src/main/kotlin/build/buf/connect/impl/BidirectionalStream.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/BidirectionalStream.kt
@@ -20,6 +20,7 @@ import build.buf.connect.StreamResult
 import build.buf.connect.http.Stream
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import java.lang.Exception
 
 /**
  * Concrete implementation of `BidirectionalStreamInterface`.
@@ -30,9 +31,14 @@ internal class BidirectionalStream<Input, Output>(
     private val receiveChannel: Channel<StreamResult<Output>>
 ) : BidirectionalStreamInterface<Input, Output> {
 
-    override suspend fun send(input: Input) {
-        val msg = requestCodec.serialize(input)
-        stream.send(msg)
+    override suspend fun send(input: Input): Result<Unit> {
+        return try {
+            val msg = requestCodec.serialize(input)
+            stream.send(msg)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
     override fun resultChannel(): ReceiveChannel<StreamResult<Output>> {

--- a/library/src/main/kotlin/build/buf/connect/impl/BidirectionalStream.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/BidirectionalStream.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import java.lang.Exception
 
 /**
- * Concrete implementation of `BidirectionalStreamInterface`.
+ * Concrete implementation of [BidirectionalStreamInterface].
  */
 internal class BidirectionalStream<Input, Output>(
     val stream: Stream,
@@ -32,13 +32,12 @@ internal class BidirectionalStream<Input, Output>(
 ) : BidirectionalStreamInterface<Input, Output> {
 
     override suspend fun send(input: Input): Result<Unit> {
-        return try {
-            val msg = requestCodec.serialize(input)
-            stream.send(msg)
-            Result.success(Unit)
+        val msg = try {
+            requestCodec.serialize(input)
         } catch (e: Exception) {
-            Result.failure(e)
+            return  Result.failure(e)
         }
+        return stream.send(msg)
     }
 
     override fun resultChannel(): ReceiveChannel<StreamResult<Output>> {
@@ -47,5 +46,9 @@ internal class BidirectionalStream<Input, Output>(
 
     override fun close() {
         stream.close()
+    }
+
+    override fun isClosed(): Boolean {
+        return stream.isClosed()
     }
 }

--- a/library/src/main/kotlin/build/buf/connect/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ClientOnlyStream.kt
@@ -23,8 +23,8 @@ import build.buf.connect.ClientOnlyStreamInterface
 internal class ClientOnlyStream<Input, Output>(
     private val messageStream: BidirectionalStreamInterface<Input, Output>
 ) : ClientOnlyStreamInterface<Input, Output> {
-    override suspend fun send(input: Input) {
-        messageStream.send(input)
+    override suspend fun send(input: Input): Result<Unit> {
+        return messageStream.send(input)
     }
 
     override fun close() {

--- a/library/src/main/kotlin/build/buf/connect/impl/ClientOnlyStream.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ClientOnlyStream.kt
@@ -18,7 +18,7 @@ import build.buf.connect.BidirectionalStreamInterface
 import build.buf.connect.ClientOnlyStreamInterface
 
 /**
- * Concrete implementation of `ClientOnlyStreamInterface`.
+ * Concrete implementation of [ClientOnlyStreamInterface].
  */
 internal class ClientOnlyStream<Input, Output>(
     private val messageStream: BidirectionalStreamInterface<Input, Output>
@@ -29,5 +29,9 @@ internal class ClientOnlyStream<Input, Output>(
 
     override fun close() {
         messageStream.close()
+    }
+
+    override fun isClosed(): Boolean {
+        return messageStream.isClosed()
     }
 }

--- a/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ProtocolClient.kt
@@ -34,7 +34,7 @@ import java.net.URL
 import kotlin.coroutines.resume
 
 /**
- * Concrete implementation of the `ProtocolClientInterface`.
+ * Concrete implementation of the [ProtocolClientInterface].
  */
 class ProtocolClient(
     // The client to use for performing requests.

--- a/library/src/main/kotlin/build/buf/connect/impl/ServerOnlyStream.kt
+++ b/library/src/main/kotlin/build/buf/connect/impl/ServerOnlyStream.kt
@@ -20,7 +20,7 @@ import build.buf.connect.StreamResult
 import kotlinx.coroutines.channels.ReceiveChannel
 
 /**
- * Concrete implementation of `ServerOnlyStreamInterface`.
+ * Concrete implementation of [ServerOnlyStreamInterface].
  */
 internal class ServerOnlyStream<Input, Output>(
     private val messageStream: BidirectionalStreamInterface<Input, Output>
@@ -29,11 +29,15 @@ internal class ServerOnlyStream<Input, Output>(
         return messageStream.resultChannel()
     }
 
-    override suspend fun send(input: Input) {
-        messageStream.send(input)
+    override suspend fun send(input: Input): Result<Unit> {
+        return messageStream.send(input)
     }
 
     override fun close() {
         messageStream.close()
+    }
+
+    override fun isClosed(): Boolean {
+        return messageStream.isClosed()
     }
 }

--- a/library/src/test/kotlin/build/buf/connect/impl/BiDirectionalStreamTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/BiDirectionalStreamTest.kt
@@ -1,0 +1,80 @@
+package build.buf.connect.impl
+
+import build.buf.connect.Codec
+import build.buf.connect.MethodSpec
+import build.buf.connect.ProtocolClientConfig
+import build.buf.connect.SerializationStrategy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import okio.Buffer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.lang.IllegalArgumentException
+
+class BiDirectionalStreamTest {
+    private val serializationStrategy: SerializationStrategy = mock { }
+    private val codec: Codec<String> = mock { }
+
+    @Test
+    fun sendOnCloseReturnsFailureResult() {
+        whenever(codec.encodingName()).thenReturn("testing")
+        whenever(codec.serialize(any())).thenReturn(Buffer())
+        whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
+
+        val client = ProtocolClient(
+            httpClient = mock { },
+            config = ProtocolClientConfig(
+                host = "https://buf.build/",
+                serializationStrategy = serializationStrategy
+            )
+        )
+
+        CoroutineScope(Dispatchers.IO).launch {
+            val stream = client.stream(
+                emptyMap(), MethodSpec(
+                    path = "build.buf.connect.SomeService/Service",
+                    String::class,
+                    String::class
+                )
+            )
+
+            stream.close()
+            val result = stream.send("input")
+            assertThat(result.isFailure).isTrue()
+        }
+    }
+
+    @Test
+    fun sendWithSerializingErrorReturnsFailureResult() {
+        whenever(codec.encodingName()).thenReturn("testing")
+        whenever(codec.serialize(any())).thenThrow(IllegalArgumentException("testing"))
+        whenever(serializationStrategy.codec<String>(any())).thenReturn(codec)
+
+        val client = ProtocolClient(
+            httpClient = mock { },
+            config = ProtocolClientConfig(
+                host = "https://buf.build/",
+                serializationStrategy = serializationStrategy
+            )
+        )
+
+        CoroutineScope(Dispatchers.IO).launch {
+            val stream = client.stream(
+                emptyMap(), MethodSpec(
+                    path = "build.buf.connect.SomeService/Service",
+                    String::class,
+                    String::class
+                )
+            )
+
+            stream.close()
+            val result = stream.send("input")
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isEqualTo(IllegalArgumentException("testing"))
+        }
+    }
+}

--- a/library/src/test/kotlin/build/buf/connect/impl/BiDirectionalStreamTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/BiDirectionalStreamTest.kt
@@ -1,3 +1,17 @@
+// Copyright 2022-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buf.connect.impl
 
 import build.buf.connect.Codec
@@ -35,7 +49,8 @@ class BiDirectionalStreamTest {
 
         CoroutineScope(Dispatchers.IO).launch {
             val stream = client.stream(
-                emptyMap(), MethodSpec(
+                emptyMap(),
+                MethodSpec(
                     path = "build.buf.connect.SomeService/Service",
                     String::class,
                     String::class
@@ -64,7 +79,8 @@ class BiDirectionalStreamTest {
 
         CoroutineScope(Dispatchers.IO).launch {
             val stream = client.stream(
-                emptyMap(), MethodSpec(
+                emptyMap(),
+                MethodSpec(
                     path = "build.buf.connect.SomeService/Service",
                     String::class,
                     String::class


### PR DESCRIPTION
Resolves https://github.com/bufbuild/connect-kotlin/issues/20

Adding a return value for the `send()` method for streams. The `Result<Unit>` will either be success or failure. For whatever reason the message sent failed on the client side, the send method will return a failure to notify the user. Otherwise, it will be a success result. This shouldn't be a backwards incompatible change as the user can still ignore the result of the send method and it would behave like it did previously.