### PR TITLE
Fix release/close as final release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
           shred signing-key
           make releasestart
       - name: sha256
-        run: sha256sum ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin.jar >> sha256.txt
+        run: |
+          make buildplugin
+          sha256sum ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin.jar >> sha256.txt
       - name: Publish GitHub artifacts
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           gpg --passphrase $GPG_PASSPHRASE --batch --import signing-key
           export ORG_GRADLE_PROJECT_signingInMemoryKey=$(gpg --armor --passphrase $GPG_PASSPHRASE --pinentry-mode=loopback --export-secret-keys $GPG_KEY_NAME signing-key | grep -v '\-\-' | grep -v '^=.' | tr -d '\n')
           shred signing-key
-          make release
+          make releasestart
       - name: sha256
         run: sha256sum ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin.jar >> sha256.txt
       - name: Publish GitHub artifacts
@@ -53,3 +53,5 @@ jobs:
           files: |
             ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin.jar
             sha256.txt
+      - name: Close repository and release
+        run: make releasecomplete

--- a/Makefile
+++ b/Makefile
@@ -103,14 +103,17 @@ lint: ## Run lint.
 lintfix: # Applies the lint changes.
 	./gradlew spotlessApply
 
-.PHONY: release
-release: ## Release artifacts to Sonatype Nexus.
-	./gradlew --info publish --stacktrace --no-daemon --no-parallel
+.PHONY: releasecomplete
+releasecomplete: ## Close release to publish artifacts to Sonatype Nexus.
 	./gradlew --info closeAndReleaseRepository
 
 .PHONY: releaselocal
 releaselocal: ## Release artifacts to local maven repository.
 	./gradlew --info publishToMavenLocal
+
+.PHONY: releasestart
+releasestart: ## Upload artifacts to Sonatype Nexus.
+	./gradlew --info publish --stacktrace --no-daemon --no-parallel
 
 .PHONY: test
 test: ## Run tests for the library.


### PR DESCRIPTION
The current release flow is the following:
1. Build the connect-kotlin runtime libraries
2. Generate `asc` files for each binary to upload
3. Upload all artifacts to sonatype release.
4. Release the uploaded artifacts and close the sonatype repository
5. Upload plugin binaries to Github releases

The main issue here is that when 4 fails, it will skip the remaining release steps.

Additionally, if any of the steps after 4 fails, a retry will not work as Sonatype will fail step 4 on a retry.

The change here is to instead handle the close repository step last