### PR TITLE
Add plugin to maven publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,5 +57,5 @@ jobs:
         generate_release_notes: true
         append_body: true
         files: |
-          ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin.jar
+          ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin-${release_version}.jar
           sha256.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,9 @@ jobs:
     steps:
     - name: sha256
       run: |
-        make buildplugin
-        sha256sum ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin.jar >> sha256.txt
+        tag=$(git describe --tags --abbrev=0 --exact-match)
+        release_version="${tag:1}"
+        sha256sum ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin-${release_version}.jar >> sha256.txt
     - name: Publish GitHub artifacts
       uses: softprops/action-gh-release@v1
       with:

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -20,6 +20,7 @@ configure<MavenPublishBaseExtension> {
         KotlinJvm(javadocJar = Dokka("dokkaGfm"))
     )
 }
+
 // Workaround for overriding the published library name to "connect-kotlin-okhttp".
 // Otherwise, the plugin will take the library name.
 extensions.getByType<PublishingExtension>().apply {

--- a/protoc-gen-connect-kotlin/build.gradle.kts
+++ b/protoc-gen-connect-kotlin/build.gradle.kts
@@ -45,7 +45,7 @@ configure<MavenPublishBaseExtension> {
     )
 }
 
-// Workaround for overriding the published library name to "connect-kotlin-okhttp".
+// Workaround for overriding the published library name.
 // Otherwise, the plugin will take the library name.
 extensions.getByType<PublishingExtension>().apply {
     publications

--- a/protoc-gen-connect-kotlin/build.gradle.kts
+++ b/protoc-gen-connect-kotlin/build.gradle.kts
@@ -1,7 +1,14 @@
+import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+
 plugins {
     application
     java
     kotlin("jvm")
+
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish.base")
 }
 
 tasks {
@@ -30,4 +37,20 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockito)
     testImplementation(libs.kotlin.coroutines.core)
+}
+
+configure<MavenPublishBaseExtension> {
+    configure(
+        KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    )
+}
+
+// Workaround for overriding the published library name to "connect-kotlin-okhttp".
+// Otherwise, the plugin will take the library name.
+extensions.getByType<PublishingExtension>().apply {
+    publications
+        .filterIsInstance<MavenPublication>()
+        .forEach { publication ->
+            publication.artifactId = "protoc-gen-connect-kotlin"
+        }
 }

--- a/protoc-gen-connect-kotlin/protoc-gen-connect-kotlin
+++ b/protoc-gen-connect-kotlin/protoc-gen-connect-kotlin
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec java -jar ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin.jar
+exec java -jar ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin-0.0.0-SNAPSHOT.jar


### PR DESCRIPTION
Adding the generator plugin to maven publish.

Gradle seems to rename the artifact locally so we'll just reference that forced name