### PR TITLE
Add @JvmOverloads on public APIs for Java users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /crosstests/google-javalite/src/main/java/generated/
 /protoc-gen-connect-kotlin/src/test/java/
 /.gradle
+/.idea
 /.tmp
 # Cache of project
 /.gradletasknamecache

--- a/library/src/main/kotlin/build/buf/connect/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/build/buf/connect/ProtocolClientConfig.kt
@@ -26,7 +26,7 @@ import java.net.URI
 /**
  *  Set of configuration used to set up clients.
  */
-class ProtocolClientConfig(
+class ProtocolClientConfig @JvmOverloads constructor(
     // The host (e.g., https://buf.build).
     val host: String,
     // The client to use for performing requests.

--- a/okhttp/src/main/kotlin/build/buf/connect/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/build/buf/connect/okhttp/ConnectOkHttpClient.kt
@@ -36,7 +36,7 @@ import java.io.IOException
 /**
  * The OkHttp implementation of HTTPClientInterface.
  */
-class ConnectOkHttpClient(
+class ConnectOkHttpClient @JvmOverloads constructor(
     val client: OkHttpClient = OkHttpClient()
 ) : HTTPClientInterface {
     override fun unary(request: HTTPRequest, onResult: (HTTPResponse) -> Unit): Cancelable {


### PR DESCRIPTION
Update ProtocolClientConfig and ConnectOkHttpClient constructors to use JvmOverloads to generate convenience methods for Java users who wish to use the defaults defined in the constructors.

Fixes #41.