### PR TITLE
Attempt to fix plugin release to github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,11 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: sha256
         run: |
-          make buildplugin
           tag=$(git describe --tags --abbrev=0 --exact-match)
           release_version="${tag:1}"
+          echo "release_version=${release_version}" >> "$GITHUB_ENV"
+          export ORG_GRADLE_PROJECT_releaseVersion="${release_version}"
+          make buildplugin
           sha256sum ./protoc-gen-connect-kotlin/build/libs/protoc-gen-connect-kotlin-${release_version}.jar >> sha256.txt
       - name: Publish GitHub artifacts
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
During the last release, we still encountered an issue in the plugin release step. Ensure we set the releaseVersion property when running the gradle build.