### PR TITLE
Replace buf and connect with connectrpc.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ It only takes ~10 minutes to complete a working chat app that uses Connect-Kotli
 
 Comprehensive documentation for everything, including
 [interceptors][interceptors], [streaming][streaming], and [error handling][error-handling]
-is available on the [connect.build website][getting-started].
+is available on the [connectrpc.com website][getting-started].
 
-## Generation Options 
+## Generation Options
 
 | **Option**                 | **Type** | **Default** | **Repeatable** | **Details**                                     |
 |----------------------------|:--------:|:-----------:|:--------------:|-------------------------------------------------|
@@ -113,10 +113,10 @@ is available on the [connect.build website][getting-started].
 
 ## Example Apps
 
-Example apps are available in [`/examples`](./examples). First, run `make generate` to generate 
+Example apps are available in [`/examples`](./examples). First, run `make generate` to generate
 code for the Protobuf plugins.
 
-For the [Android example](./examples/android), you can run `make installandroid` to build and install 
+For the [Android example](./examples/android), you can run `make installandroid` to build and install
 a fully functional Android application using Connect-Kotlin.
 
 Additionally, there are pure Kotlin examples that demonstrate a simple main executable using Connect-Kotlin:
@@ -163,17 +163,17 @@ Offered under the [Apache 2 license][license].
 [buf-studio]: https://buf.build/studio
 [connect-crosstest]: https://github.com/bufbuild/connect-crosstest
 [connect-go]: https://github.com/bufbuild/connect-go
-[connect-protocol]: https://connect.build/docs/protocol
+[connect-protocol]: https://connectrpc.com/docs/protocol
 [connect-swift]: https://github.com/bufbuild/connect-swift
 [connect-web]: https://www.npmjs.com/package/@bufbuild/connect-web
-[error-handling]: https://connect.build/docs/kotlin/errors
-[getting-started]: https://connect.build/docs/kotlin/getting-started
+[error-handling]: https://connectrpc.com/docs/kotlin/errors
+[getting-started]: https://connectrpc.com/docs/kotlin/getting-started
 [grpc-protocol]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
 [grpc-web-protocol]: https://github.com/grpc/grpc-web
-[interceptors]: https://connect.build/docs/kotlin/interceptors
+[interceptors]: https://connectrpc.com/docs/kotlin/interceptors
 [license]: https://github.com/bufbuild/connect-go/blob/main/LICENSE
 [protobuf]: https://developers.google.com/protocol-buffers
-[protocol]: https://connect.build/docs/protocol
+[protocol]: https://connectrpc.com/docs/protocol
 [server reflection]: https://github.com/bufbuild/connect-grpcreflect-go
 [slack]: https://buf.build/links/slack
-[streaming]: https://connect.build/docs/kotlin/using-clients#using-generated-clients
+[streaming]: https://connectrpc.com/docs/kotlin/using-clients#using-generated-clients

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -1,13 +1,13 @@
 # Eliza chat app example
 
 This example app uses the `Connect` library and provides an interface for
-[chatting with Eliza](https://buf.build/bufbuild/eliza) via an Android application.
+[chatting with Eliza](https://connectrpc.com/bufbuild/eliza) via an Android application.
 
 The app has support for chatting using a variety of protocols supported by
 the Connect-Kotlin library:
 
-- [Connect](https://connect.build) + unary
-- [Connect](https://connect.build) + streaming
+- [Connect](https://connectrpc.com) + unary
+- [Connect](https://connectrpc.com) + streaming
 - [gRPC](https://grpc.io) + unary
 - [gRPC](https://grpc.io) + streaming
 - [gRPC-Web](https://grpc.io) + unary

--- a/examples/android/src/main/kotlin/build/buf/connect/examples/android/ElizaChatActivity.kt
+++ b/examples/android/src/main/kotlin/build/buf/connect/examples/android/ElizaChatActivity.kt
@@ -60,7 +60,7 @@ class ElizaChatActivity : AppCompatActivity() {
             .writeTimeout(10, TimeUnit.MINUTES)
             .callTimeout(10, TimeUnit.MINUTES)
             .build()
-        val host = "https://demo.connect.build"
+        val host = "https://demo.connectrpc.com"
         val protocol = intent.getStringExtra(PROTOCOL_KEY)
         // Get the user selected protocol.
         val selectedNetworkProtocolOption = when (protocol) {

--- a/examples/kotlin-google-java/src/main/kotlin/build/buf/connect/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-java/src/main/kotlin/build/buf/connect/examples/kotlin/Main.kt
@@ -32,7 +32,7 @@ class Main {
         @JvmStatic
         fun main(args: Array<String>) {
             runBlocking {
-                val host = "https://demo.connect.build"
+                val host = "https://demo.connectrpc.com"
                 val client = ProtocolClient(
                     httpClient = ConnectOkHttpClient(
                         OkHttpClient()

--- a/examples/kotlin-google-javalite/src/main/kotlin/build/buf/connect/examples/kotlin/Main.kt
+++ b/examples/kotlin-google-javalite/src/main/kotlin/build/buf/connect/examples/kotlin/Main.kt
@@ -32,7 +32,7 @@ class Main {
         @JvmStatic
         fun main(args: Array<String>) {
             runBlocking {
-                val host = "https://demo.connect.build"
+                val host = "https://demo.connectrpc.com"
                 val client = ProtocolClient(
                     httpClient = ConnectOkHttpClient(
                         OkHttpClient()

--- a/library/src/main/kotlin/build/buf/connect/Code.kt
+++ b/library/src/main/kotlin/build/buf/connect/Code.kt
@@ -39,7 +39,7 @@ enum class Code(val codeName: String, val value: Int) {
     UNAUTHENTICATED("unauthenticated", 16);
 
     companion object {
-        // https://connect.build/docs/protocol#http-to-error-code
+        // https://connectrpc.com/docs/protocol#http-to-error-code
         fun fromHTTPStatus(status: Int): Code {
             return when (status) {
                 200 -> OK

--- a/library/src/main/kotlin/build/buf/connect/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/build/buf/connect/ProtocolClientConfig.kt
@@ -27,7 +27,7 @@ import java.net.URI
  *  Set of configuration used to set up clients.
  */
 class ProtocolClientConfig @JvmOverloads constructor(
-    // The host (e.g., https://buf.build).
+    // The host (e.g., https://connectrpc.com).
     val host: String,
     // The client to use for performing requests.
     // The serialization strategy for decoding messages.

--- a/library/src/main/kotlin/build/buf/connect/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/build/buf/connect/protocols/ConnectInterceptor.kt
@@ -41,7 +41,7 @@ import java.net.URL
 
 /**
  * The Connect protocol.
- * https://connect.build/docs
+ * https://connectrpc.com/docs
  */
 internal class ConnectInterceptor(
     private val clientConfig: ProtocolClientConfig

--- a/library/src/test/kotlin/build/buf/connect/InterceptorChainTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/InterceptorChainTest.kt
@@ -64,7 +64,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_unary() {
-        val response = unaryChain.requestFunction(HTTPRequest(URL("https://buf.build"), "", emptyMap(), null, methodSpec))
+        val response = unaryChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), null, methodSpec))
         assertThat(response.headers.get("id")).containsExactly("1", "2", "3", "4")
     }
 
@@ -76,7 +76,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_stream() {
-        val request = streamingChain.requestFunction(HTTPRequest(URL("https://buf.build"), "", emptyMap(), null, methodSpec))
+        val request = streamingChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", emptyMap(), null, methodSpec))
         assertThat(request.headers.get("id")).containsExactly("1", "2", "3", "4")
     }
 

--- a/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/ProtocolClientConfigTest.kt
@@ -26,17 +26,17 @@ class ProtocolClientConfigTest {
     @Test
     fun hostUri() {
         val config = ProtocolClientConfig(
-            host = "https://connect.build",
+            host = "https://connectrpc.com",
             serializationStrategy = mock { }
         )
-        assertThat(config.baseUri.host).isEqualTo("connect.build")
+        assertThat(config.baseUri.host).isEqualTo("connectrpc.com")
         assertThat(config.baseUri.toURL()).isNotNull()
     }
 
     @Test(expected = MalformedURLException::class)
     fun unsupportedSchemeErrorsWhenTranslatingToURL() {
         val config = ProtocolClientConfig(
-            host = "xhtp://connect.build",
+            host = "xhtp://connectrpc.com",
             serializationStrategy = mock { }
         )
         config.baseUri.toURL()

--- a/library/src/test/kotlin/build/buf/connect/impl/BiDirectionalStreamTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/BiDirectionalStreamTest.kt
@@ -42,7 +42,7 @@ class BiDirectionalStreamTest {
         val client = ProtocolClient(
             httpClient = mock { },
             config = ProtocolClientConfig(
-                host = "https://buf.build/",
+                host = "https://connectrpc.com/",
                 serializationStrategy = serializationStrategy
             )
         )
@@ -72,7 +72,7 @@ class BiDirectionalStreamTest {
         val client = ProtocolClient(
             httpClient = mock { },
             config = ProtocolClientConfig(
-                host = "https://buf.build/",
+                host = "https://connectrpc.com/",
                 serializationStrategy = serializationStrategy
             )
         )

--- a/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/impl/ProtocolClientTest.kt
@@ -46,7 +46,7 @@ class ProtocolClientTest {
         val client = ProtocolClient(
             httpClient = httpClient,
             config = ProtocolClientConfig(
-                host = "https://buf.build/",
+                host = "https://connectrpc.com/",
                 serializationStrategy = serializationStrategy
             )
         )
@@ -70,7 +70,7 @@ class ProtocolClientTest {
         val client = ProtocolClient(
             httpClient = httpClient,
             config = ProtocolClientConfig(
-                host = "https://buf.build",
+                host = "https://connectrpc.com",
                 serializationStrategy = serializationStrategy
             )
         )
@@ -94,7 +94,7 @@ class ProtocolClientTest {
         val client = ProtocolClient(
             httpClient = httpClient,
             config = ProtocolClientConfig(
-                host = "https://buf.build/",
+                host = "https://connectrpc.com/",
                 serializationStrategy = serializationStrategy
             )
         )
@@ -119,7 +119,7 @@ class ProtocolClientTest {
         val client = ProtocolClient(
             httpClient = httpClient,
             config = ProtocolClientConfig(
-                host = "https://buf.build",
+                host = "https://connectrpc.com",
                 serializationStrategy = serializationStrategy
             )
         )
@@ -143,7 +143,7 @@ class ProtocolClientTest {
         val client = ProtocolClient(
             httpClient = httpClient,
             config = ProtocolClientConfig(
-                host = "https://buf.build",
+                host = "https://connectrpc.com",
                 serializationStrategy = serializationStrategy
             )
         )
@@ -160,7 +160,7 @@ class ProtocolClientTest {
         // Use HTTP client to determine and verify the final URL.
         val captor = argumentCaptor<HTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
-        assertThat(captor.firstValue.url.toString()).isEqualTo("https://buf.build/build.buf.connect.SomeService/Service")
+        assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/build.buf.connect.SomeService/Service")
     }
 
     @Test
@@ -171,7 +171,7 @@ class ProtocolClientTest {
         val client = ProtocolClient(
             httpClient = httpClient,
             config = ProtocolClientConfig(
-                host = "https://buf.build/",
+                host = "https://connectrpc.com/",
                 serializationStrategy = serializationStrategy
             )
         )
@@ -188,6 +188,6 @@ class ProtocolClientTest {
         // Use HTTP client to determine and verify the final URL.
         val captor = argumentCaptor<HTTPRequest>()
         verify(httpClient).unary(captor.capture(), any())
-        assertThat(captor.firstValue.url.toString()).isEqualTo("https://buf.build/build.buf.connect.SomeService/Service")
+        assertThat(captor.firstValue.url.toString()).isEqualTo("https://connectrpc.com/build.buf.connect.SomeService/Service")
     }
 }

--- a/library/src/test/kotlin/build/buf/connect/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/protocols/ConnectInterceptorTest.kt
@@ -66,7 +66,7 @@ class ConnectInterceptorTest {
     @Test
     fun requestHeaders() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList()
         )
@@ -95,7 +95,7 @@ class ConnectInterceptorTest {
     @Test
     fun uncompressedRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val connectInterceptor = ConnectInterceptor(config)
@@ -120,7 +120,7 @@ class ConnectInterceptorTest {
     @Test
     fun compressedRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
             compressionPools = listOf(GzipCompressionPool)
@@ -148,7 +148,7 @@ class ConnectInterceptorTest {
     @Test
     fun uncompressedResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -170,7 +170,7 @@ class ConnectInterceptorTest {
     @Test
     fun compressedResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -192,7 +192,7 @@ class ConnectInterceptorTest {
     @Test
     fun responseError() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -230,7 +230,7 @@ class ConnectInterceptorTest {
     @Test
     fun responseErrorBadJSON() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -252,7 +252,7 @@ class ConnectInterceptorTest {
     @Test
     fun tracingInfoForwardedOnUnaryResponse() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = ConnectInterceptor(config)
@@ -276,7 +276,7 @@ class ConnectInterceptorTest {
     @Test
     fun streamingRequestHeadersWithCompression() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
             compressionPools = listOf(GzipCompressionPool)
@@ -306,7 +306,7 @@ class ConnectInterceptorTest {
     @Test
     fun streamingRequestHeadersNoCompression() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList()
         )
@@ -335,7 +335,7 @@ class ConnectInterceptorTest {
     @Test
     fun uncompressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val connectInterceptor = ConnectInterceptor(config)
@@ -349,7 +349,7 @@ class ConnectInterceptorTest {
     @Test
     fun compressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -364,7 +364,7 @@ class ConnectInterceptorTest {
     @Test
     fun streamingResponseHeaders() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -388,7 +388,7 @@ class ConnectInterceptorTest {
     @Test
     fun uncompressedStreamingResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -412,7 +412,7 @@ class ConnectInterceptorTest {
     @Test
     fun compressedStreamingResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
             compressionPools = listOf(GzipCompressionPool)
@@ -443,7 +443,7 @@ class ConnectInterceptorTest {
     @Test
     fun endStreamOnResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val connectInterceptor = ConnectInterceptor(config)
@@ -488,7 +488,7 @@ class ConnectInterceptorTest {
     @Test
     fun endStreamResponseBadJSON() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val connectInterceptor = ConnectInterceptor(config)
@@ -507,7 +507,7 @@ class ConnectInterceptorTest {
     @Test
     fun endStreamOnTrailers() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val connectInterceptor = ConnectInterceptor(config)
@@ -531,7 +531,7 @@ class ConnectInterceptorTest {
     @Test
     fun endStreamForwardsErrors() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val connectInterceptor = ConnectInterceptor(config)
@@ -555,7 +555,7 @@ class ConnectInterceptorTest {
     @Test
     fun getRequestCreatedForPayloadUnderLimit() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
             getConfiguration = GETConfiguration.EnabledWithFallback(
@@ -591,7 +591,7 @@ class ConnectInterceptorTest {
     @Test
     fun fallbackRequestCreatedForPayloadOverLimit() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
             getConfiguration = GETConfiguration.EnabledWithFallback(
@@ -622,7 +622,7 @@ class ConnectInterceptorTest {
     @Test
     fun getRequestCreatedForNoFallbackEnabled() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
             getConfiguration = GETConfiguration.Enabled
@@ -654,7 +654,7 @@ class ConnectInterceptorTest {
     @Test
     fun unaryPostRequestCreatedWithGetDisabled() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = emptyList(),
             getConfiguration = GETConfiguration.Disabled

--- a/library/src/test/kotlin/build/buf/connect/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/protocols/GRPCInterceptorTest.kt
@@ -60,7 +60,7 @@ class GRPCInterceptorTest {
     @Test
     fun requestHeaders() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcInterceptor = GRPCInterceptor(config)
@@ -87,7 +87,7 @@ class GRPCInterceptorTest {
     @Test
     fun uncompressedRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcInterceptor = GRPCInterceptor(config)
@@ -113,7 +113,7 @@ class GRPCInterceptorTest {
     @Test
     fun compressedRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
             compressionPools = listOf(GzipCompressionPool)
@@ -142,7 +142,7 @@ class GRPCInterceptorTest {
     @Test
     fun uncompressedResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
 
@@ -170,7 +170,7 @@ class GRPCInterceptorTest {
     @Test
     fun compressedResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -204,7 +204,7 @@ class GRPCInterceptorTest {
             )
         )
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -246,7 +246,7 @@ class GRPCInterceptorTest {
     @Test
     fun tracingInfoForwardedOnUnaryResponse() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCInterceptor(config)
@@ -270,7 +270,7 @@ class GRPCInterceptorTest {
     @Test
     fun streamingRequestHeadersWithCompression() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
             compressionPools = listOf(GzipCompressionPool)
@@ -302,7 +302,7 @@ class GRPCInterceptorTest {
     @Test
     fun streamingRequestHeadersWithoutAnyCompression() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcInterceptor = GRPCInterceptor(config)
@@ -328,7 +328,7 @@ class GRPCInterceptorTest {
     @Test
     fun uncompressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcInterceptor = GRPCInterceptor(config)
@@ -342,7 +342,7 @@ class GRPCInterceptorTest {
     @Test
     fun compressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -357,7 +357,7 @@ class GRPCInterceptorTest {
     @Test
     fun streamingResponseHeaders() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -380,7 +380,7 @@ class GRPCInterceptorTest {
     @Test
     fun uncompressedStreamingResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -404,7 +404,7 @@ class GRPCInterceptorTest {
     @Test
     fun compressedStreamingResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -434,7 +434,7 @@ class GRPCInterceptorTest {
     @Test
     fun endStreamOnTrailers() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcInterceptor = GRPCInterceptor(config)
@@ -459,7 +459,7 @@ class GRPCInterceptorTest {
     @Test
     fun endStreamForwardsErrors() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcInterceptor = GRPCInterceptor(config)

--- a/library/src/test/kotlin/build/buf/connect/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/protocols/GRPCWebInterceptorTest.kt
@@ -53,7 +53,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun requestHeaders() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
@@ -80,7 +80,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun uncompressedRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
@@ -106,7 +106,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun compressedRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1, GzipCompressionPool),
             compressionPools = listOf(GzipCompressionPool)
@@ -134,7 +134,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun uncompressedResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -157,7 +157,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun compressedResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -180,7 +180,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun failureOnResponseHeaders() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -204,7 +204,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun responseErrorWithOnlyTrailers() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -231,7 +231,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun responseErrorWithTrailers() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -263,7 +263,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun tracingInfoForwardedOnUnaryResponse() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
@@ -287,7 +287,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun streamingRequestHeadersWithCompression() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             requestCompression = RequestCompression(1000, GzipCompressionPool),
             compressionPools = listOf(GzipCompressionPool)
@@ -317,7 +317,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun streamingRequestHeadersNoCompression() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
@@ -342,7 +342,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun uncompressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
@@ -356,7 +356,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun compressedStreamingRequestMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -371,7 +371,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun streamingResponseHeaders() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -397,7 +397,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun uncompressedStreamingResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -419,7 +419,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun compressedStreamingResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy,
             compressionPools = listOf(GzipCompressionPool)
         )
@@ -447,7 +447,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun endStreamOnResponseMessage() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
@@ -472,7 +472,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun endStreamOnTrailers() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)
@@ -496,7 +496,7 @@ class GRPCWebInterceptorTest {
     @Test
     fun endStreamForwardsErrors() {
         val config = ProtocolClientConfig(
-            host = "https://buf.build",
+            host = "https://connectrpc.com",
             serializationStrategy = serializationStrategy
         )
         val grpcWebInterceptor = GRPCWebInterceptor(config)


### PR DESCRIPTION
Searched for `connect.build` and `buf.build` to replace appropriate usages to `connectrpc.com`