### PR TITLE
Migrate crosstests to use testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,8 @@ jobs:
           cache: false
       - name: Generate proto files for cross tests.
         run: make generatecrosstests
-      - name: Start test server
-        run: make crosstestserverrun
       - name: Run crosstests
         run: make crosstestsrun
-      - name: Stop test server
-        run: make crosstestserverstop
   license-headers:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
 CACHE := .tmp/cache
 LICENSE_HEADER_YEAR_RANGE := 2022-2023
-CROSSTEST_VERSION := 162d496c009e2ffb1a638b4a2ea789e9cc3331bb
 LICENSE_HEADER_VERSION := v1.26.1
 PROTOC_VERSION ?= 24.1
 GRADLE_ARGS ?=
@@ -26,7 +25,7 @@ $(BIN)/license-headers: Makefile
 
 .PHONY: build
 build: generate ## Build the entire project.
-	./gradlew $(GRADLE_ARGS) build -x test
+	./gradlew $(GRADLE_ARGS) build
 
 .PHONY: buildplugin
 buildplugin: ## Build the connect-kotlin protoc plugin.
@@ -44,19 +43,6 @@ clean: ## Cleans the underlying build.
 	rm -rf crosstests/google-javalite/src/main/kotlin/generated
 
 	rm -rf protoc-gen-connect-kotlin/src/test/java/
-
-.PHONY: crosstestserverrun
-crosstestserverrun: crosstestserverstop ## Run the server for cross tests.
-	docker run --rm --name serverconnect -p 8080:8080 -p 8081:8081 -d \
-		bufbuild/connect-crosstest:$(CROSSTEST_VERSION) \
-		/usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --cert "cert/localhost.crt" --key "cert/localhost.key"
-	docker run --rm --name servergrpc -p 8083:8083 -d \
-		bufbuild/connect-crosstest:$(CROSSTEST_VERSION) \
-		/usr/local/bin/servergrpc --port "8083" --cert "cert/localhost.crt" --key "cert/localhost.key"
-
-.PHONY: crosstestserverstop
-crosstestserverstop: ## Stop the server for cross tests.
-	-docker container stop serverconnect servergrpc
 
 .PHONY: crosstestsrun
 crosstestsrun: crosstestsrunjava ## Run the cross tests.

--- a/crosstests/google-java/build.gradle.kts
+++ b/crosstests/google-java/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockito)
     testImplementation(libs.kotlin.coroutines.core)
+    testImplementation(libs.testcontainers)
 }
 
 configure<SpotlessExtension> {

--- a/crosstests/google-java/src/test/kotlin/build/buf/connect/crosstest/CrossTest.kt
+++ b/crosstests/google-java/src/test/kotlin/build/buf/connect/crosstest/CrossTest.kt
@@ -43,10 +43,12 @@ import okhttp3.Protocol
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before
+import org.junit.ClassRule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
+import org.testcontainers.containers.GenericContainer
 import java.time.Duration
 import java.util.Base64
 import java.util.concurrent.CountDownLatch
@@ -63,6 +65,8 @@ class CrossTest(
     private lateinit var testServiceConnectClient: TestServiceClient
 
     companion object {
+        const val CROSSTEST_VERSION = "162d496c009e2ffb1a638b4a2ea789e9cc3331bb"
+
         @JvmStatic
         @Parameters(name = "protocol")
         fun data(): Iterable<NetworkProtocol> {
@@ -71,12 +75,27 @@ class CrossTest(
                 NetworkProtocol.GRPC
             )
         }
+
+        @JvmField
+        @ClassRule
+        val CROSSTEST_CONTAINER = GenericContainer("bufbuild/connect-crosstest:${CROSSTEST_VERSION}")
+            .withExposedPorts(8080, 8081)
+            .withCommand(
+                "/usr/local/bin/serverconnect",
+                "--h1port",
+                "8080",
+                "--h2port",
+                "8081",
+                "--cert",
+                "cert/localhost.crt",
+                "--key",
+                "cert/localhost.key",
+            )
     }
 
     @Before
     fun before() {
-        val port = 8081
-        val host = "https://localhost:$port"
+        val host = "https://localhost:${CROSSTEST_CONTAINER.getMappedPort(8081)}"
         val (sslSocketFactory, trustManager) = sslContext()
         val client = OkHttpClient.Builder()
             .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))

--- a/crosstests/google-java/src/test/kotlin/build/buf/connect/crosstest/CrossTest.kt
+++ b/crosstests/google-java/src/test/kotlin/build/buf/connect/crosstest/CrossTest.kt
@@ -78,7 +78,7 @@ class CrossTest(
 
         @JvmField
         @ClassRule
-        val CROSSTEST_CONTAINER = GenericContainer("bufbuild/connect-crosstest:${CROSSTEST_VERSION}")
+        val CROSSTEST_CONTAINER = GenericContainer("bufbuild/connect-crosstest:$CROSSTEST_VERSION")
             .withExposedPorts(8080, 8081)
             .withCommand(
                 "/usr/local/bin/serverconnect",
@@ -89,7 +89,7 @@ class CrossTest(
                 "--cert",
                 "cert/localhost.crt",
                 "--key",
-                "cert/localhost.key",
+                "cert/localhost.key"
             )
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf" }
 protobuf-kotlinlite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.13.0" }
+testcontainers = { module = "org.testcontainers:testcontainers", version = "1.19.0" }
 
 [plugins]
 git = { id = "com.palantir.git-version", version = "3.0.0" }


### PR DESCRIPTION
Instead of manually having to exclude tests from `./gradlew build` (since the crosstest tests fail if the Docker server isn't running), migrate the crosstests to use testcontainers to spin up the server so the tests can always run. This also simplifies the makefile - we no longer need to manually start/stop the crosstests server and also don't need to bind to static ports on the host - it will use ephemeral ports.
