### PR TITLE
Switch JSON serde to use codegen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        gradlePluginPortal()
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 maven-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenplugin" }
 mockito = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.1.0" }
 moshiKotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
+moshiKotlinCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }
 okio-core = { module = "com.squareup.okio:okio", version.ref = "okio" }
@@ -49,3 +50,4 @@ testcontainers = { module = "org.testcontainers:testcontainers", version = "1.19
 
 [plugins]
 git = { id = "com.palantir.git-version", version = "3.0.0" }
+ksp = { id = "com.google.devtools.ksp", version = "1.6.21-1.0.6" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
     id("com.vanniktech.maven.publish.base")
+    alias(libs.plugins.ksp)
 }
 
 dependencies {
@@ -15,6 +16,8 @@ dependencies {
 
     implementation(libs.moshiKotlin)
     implementation(libs.kotlin.coroutines.core)
+
+    ksp(libs.moshiKotlinCodegen)
 }
 
 configure<MavenPublishBaseExtension> {

--- a/library/src/main/kotlin/build/buf/connect/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/build/buf/connect/protocols/ConnectInterceptor.kt
@@ -46,9 +46,7 @@ import java.net.URL
 internal class ConnectInterceptor(
     private val clientConfig: ProtocolClientConfig
 ) : Interceptor {
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
     private val serializationStrategy = clientConfig.serializationStrategy
     private var responseCompressionPool: CompressionPool? = null
 

--- a/library/src/main/kotlin/build/buf/connect/protocols/ConnectInterceptor.kt
+++ b/library/src/main/kotlin/build/buf/connect/protocols/ConnectInterceptor.kt
@@ -33,7 +33,6 @@ import build.buf.connect.compression.CompressionPool
 import build.buf.connect.http.HTTPRequest
 import build.buf.connect.http.HTTPResponse
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8

--- a/library/src/main/kotlin/build/buf/connect/protocols/ErrorJSONModels.kt
+++ b/library/src/main/kotlin/build/buf/connect/protocols/ErrorJSONModels.kt
@@ -15,18 +15,22 @@
 package build.buf.connect.protocols
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 internal class ErrorPayloadJSON(
     @Json(name = "code") val code: String?,
     @Json(name = "message") val message: String?,
     @Json(name = "details") val details: List<ErrorDetailPayloadJSON>?
 )
 
+@JsonClass(generateAdapter = true)
 internal class ErrorDetailPayloadJSON(
     @Json(name = "type") val type: String?,
     @Json(name = "value") val value: String?
 )
 
+@JsonClass(generateAdapter = true)
 internal class EndStreamResponseJSON(
     @Json(name = "error") val error: ErrorPayloadJSON?,
     @Json(name = "metadata") val metadata: Map<String, List<String>>?

--- a/library/src/test/kotlin/build/buf/connect/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/protocols/ConnectInterceptorTest.kt
@@ -47,9 +47,7 @@ class ConnectInterceptorTest {
     private val errorDetailParser: ErrorDetailParser = mock { }
     private val serializationStrategy: SerializationStrategy = mock { }
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
 
     @Before
     fun setup() {

--- a/library/src/test/kotlin/build/buf/connect/protocols/ConnectInterceptorTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/protocols/ConnectInterceptorTest.kt
@@ -31,7 +31,6 @@ import build.buf.connect.http.HTTPRequest
 import build.buf.connect.http.HTTPResponse
 import build.buf.connect.http.TracingInfo
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
 import okio.internal.commonAsUtf8ToByteArray

--- a/library/src/test/kotlin/build/buf/connect/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/protocols/GRPCInterceptorTest.kt
@@ -28,7 +28,6 @@ import build.buf.connect.http.HTTPRequest
 import build.buf.connect.http.HTTPResponse
 import build.buf.connect.http.TracingInfo
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
 import okio.internal.commonAsUtf8ToByteArray

--- a/library/src/test/kotlin/build/buf/connect/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/build/buf/connect/protocols/GRPCInterceptorTest.kt
@@ -44,9 +44,7 @@ class GRPCInterceptorTest {
 
     private val errorDetailParser: ErrorDetailParser = mock { }
     private val serializationStrategy: SerializationStrategy = mock { }
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
 
     @Before
     fun setup() {


### PR DESCRIPTION
Update JSON serialization/deserialization to use codegen instead of reflection. This improves performance and also generates some proguard rules, so it should help in issue #89.