### PR TITLE
Release depends on generated proto code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ lintfix: # Applies the lint changes.
 	./gradlew $(GRADLE_ARGS) spotlessApply
 
 .PHONY: release
-release: ## Upload artifacts to Sonatype Nexus.
+release: generate ## Upload artifacts to Sonatype Nexus.
 	./gradlew $(GRADLE_ARGS) --info publish --stacktrace --no-daemon --no-parallel
 	./gradlew $(GRADLE_ARGS) --info closeAndReleaseRepository
 


### PR DESCRIPTION
Since the googleapis Status files were removed from source control (and are created using 'make generate'), we need to update the release workflow to run generate prior to releasing code.
